### PR TITLE
Use TARGETS_REGULAR if the recursive flag is not set

### DIFF
--- a/src/zfs-auto-snapshot.sh
+++ b/src/zfs-auto-snapshot.sh
@@ -567,15 +567,24 @@ do
 		fi
 	done
 
-	# Append this candidate to the recursive snapshot list because it:
+	# Append this candidate to the snapshot list because it:
 	#
 	#   * Does not have an exclusionary property.
 	#   * Is in a pool that can currently do snapshots.
-	#   * Does not have an excluded descendent filesystem.
-	#   * Is not the descendant of an already included filesystem.
 	#
-	print_log debug "Including $ii for recursive snapshot."
-	TARGETS_RECURSIVE="${TARGETS_RECURSIVE:+$TARGETS_RECURSIVE	}$ii" # nb: \t
+	if [ -z "$opt_recursive" ]
+	then
+		print_log debug "Including $ii for regular snapshot."
+		TARGETS_REGULAR="${TARGETS_REGULAR:+$TARGETS_REGULAR	}$ii" # nb: \t
+	else
+		# Append this candidate to the recursive snapshot list because it additionally:
+		#
+		#   * Does not have an excluded descendent filesystem.
+		#   * Is not the descendant of an already included filesystem.
+		#
+		print_log debug "Including $ii for recursive snapshot."
+		TARGETS_RECURSIVE="${TARGETS_RECURSIVE:+$TARGETS_RECURSIVE	}$ii" # nb: \t
+	fi
 done
 
 # Linux lacks SMF and the notion of an FMRI event, but always set this property


### PR DESCRIPTION
The program currently stores all targets into `TARGETS_RECURSIVE` even
if the `--recursive` flag is not set. This causes the program to
incorrectly snapshot only the most-ancestral datasets in the list. For
example, the following invocation would only snapshot datasets `a` and
`b`:

    $ zfs-snapshot-auto a a\child1 a\child2 b b\child1 b\child2

Instead, we should be storing each valid dataset in `TARGETS_REGULAR`
so that they can be backed up individually. This commit tests wether
the flag is set before deciding whih variable to update.

Fixes: #83